### PR TITLE
Hiding the top nav on the Homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,13 +46,13 @@
     <div class="w-container">
       <a href="index.html" class="w-nav-brand brand-link"><img width="100%" src="images/Logo 2 - 1.2.png">
       </a>
-      <nav role="navigation" class="w-nav-menu nav-menu">
+      <!--nav role="navigation" class="w-nav-menu nav-menu">
         <a href="#flow" class="w-nav-link nav-link">民調流程</a>
         <a data-ix="invisible" class="w-nav-link nav-link">最新民調結果</a>
         <a href="#why" class="w-nav-link nav-link">策略性投票</a>
         <a href="#" data-ix="invisible" class="w-nav-link nav-link">English</a>
         <a href="invitation.html" class="w-nav-link nav-link">即刻投票!</a>
-      </nav>
+      </nav-->
       <div class="w-nav-button nav-link menu">
         <div class="w-icon-nav-menu"></div>
       </div>


### PR DESCRIPTION
Because the Homepage is currently for the general public without the invitations and they don't need to see these links on the Home page. People who have the invitation link can click to vote on the Invitation page instead.
